### PR TITLE
Integrate Flutter home page with backend search API

### DIFF
--- a/frontend/vital_sync_app/lib/core/constants/config.dart
+++ b/frontend/vital_sync_app/lib/core/constants/config.dart
@@ -1,3 +1,6 @@
 class Config {
-  final String vitalSyncApiUrl = 'https://api.vitalsync.com';
+  /// Base URL of the VitalSync backend API.
+  ///
+  /// Update this value if the backend is hosted elsewhere.
+  final String vitalSyncApiUrl = 'http://127.0.0.1:8000';
 }

--- a/frontend/vital_sync_app/lib/core/services/vital_sync_api_service.dart
+++ b/frontend/vital_sync_app/lib/core/services/vital_sync_api_service.dart
@@ -15,19 +15,19 @@ class VitalSyncApiService {
     );
   }
 
-  Future<List<dynamic>> get(String endpoint) async {
+  Future<dynamic> get(String endpoint) async {
     try {
-      Response response = await _dio.get("$endpoint/");
+      final Response response = await _dio.get(endpoint);
       return response.data;
     } catch (e) {
-      print("Error fetching users: $e");
-      return [];
+      print("Error fetching data: $e");
+      return null;
     }
   }
 
   Future<dynamic> post(String endpoint, Map<String, dynamic> data) async {
     try {
-      Response response = await _dio.post("$endpoint/", data: data);
+      final Response response = await _dio.post(endpoint, data: data);
       return response.data;
     } catch (e) {
       print("Error posting data: $e");
@@ -37,7 +37,7 @@ class VitalSyncApiService {
 
   Future<dynamic> put(String endpoint, Map<String, dynamic> data) async {
     try {
-      Response response = await _dio.put("$endpoint/", data: data);
+      final Response response = await _dio.put(endpoint, data: data);
       return response.data;
     } catch (e) {
       print("Error updating data: $e");
@@ -47,7 +47,7 @@ class VitalSyncApiService {
 
   Future<dynamic> delete(String endpoint) async {
     try {
-      Response response = await _dio.delete("$endpoint/");
+      final Response response = await _dio.delete(endpoint);
       return response.data;
     } catch (e) {
       print("Error deleting data: $e");

--- a/frontend/vital_sync_app/lib/data/repositories/data_repository.dart
+++ b/frontend/vital_sync_app/lib/data/repositories/data_repository.dart
@@ -6,8 +6,19 @@ class DataRepository {
 
   DataRepository({required this.apiService});
 
-  Future<List<Data>> fetchUsers() async {
-    final data = await apiService.get('users');
-    return data.map((json) => Data.fromJson(json)).toList();
+  /// Fetch a paginated list of data records for the given [userId].
+  Future<List<Data>> searchData({
+    required String userId,
+    int page = 0,
+    int limit = 100,
+  }) async {
+    final response = await apiService
+        .get('data/search?user_id=$userId&page=$page&limit=$limit');
+
+    if (response is Map<String, dynamic>) {
+      final List<dynamic> list = response['data'] ?? [];
+      return list.map((e) => Data.fromJson(e)).toList();
+    }
+    return [];
   }
 }

--- a/frontend/vital_sync_app/lib/features/home/bloc/home_event.dart
+++ b/frontend/vital_sync_app/lib/features/home/bloc/home_event.dart
@@ -1,5 +1,16 @@
-abstract class HomeEvent {}
+import 'package:equatable/equatable.dart';
 
-class LoadSensorData extends HomeEvent {}
+abstract class HomeEvent extends Equatable {
+  const HomeEvent();
 
-class RefreshSensorData extends HomeEvent {}
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadSensorData extends HomeEvent {
+  const LoadSensorData();
+}
+
+class RefreshSensorData extends HomeEvent {
+  const RefreshSensorData();
+}

--- a/frontend/vital_sync_app/lib/features/home/bloc/home_state.dart
+++ b/frontend/vital_sync_app/lib/features/home/bloc/home_state.dart
@@ -1,8 +1,19 @@
-abstract class HomeState {}
+import 'package:equatable/equatable.dart';
 
-class HomeInitial extends HomeState {}
+abstract class HomeState extends Equatable {
+  const HomeState();
 
-class HomeLoading extends HomeState {}
+  @override
+  List<Object?> get props => [];
+}
+
+class HomeInitial extends HomeState {
+  const HomeInitial();
+}
+
+class HomeLoading extends HomeState {
+  const HomeLoading();
+}
 
 class HomeLoaded extends HomeState {
   final int heartRate;
@@ -11,16 +22,23 @@ class HomeLoaded extends HomeState {
   final int exerciseStreak;
   final int caloriesBurned;
 
-  HomeLoaded({
+  const HomeLoaded({
     required this.heartRate,
     required this.stepCount,
     required this.oxygenLevel,
     required this.exerciseStreak,
     required this.caloriesBurned,
   });
+
+  @override
+  List<Object?> get props =>
+      [heartRate, stepCount, oxygenLevel, exerciseStreak, caloriesBurned];
 }
 
 class HomeError extends HomeState {
   final String message;
-  HomeError({required this.message});
+  const HomeError({required this.message});
+
+  @override
+  List<Object?> get props => [message];
 }

--- a/frontend/vital_sync_app/lib/features/home/view/home_page.dart
+++ b/frontend/vital_sync_app/lib/features/home/view/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../../../core/services/sensor_service.dart';
+import '../../../core/services/vital_sync_api_service.dart';
+import '../../../data/repositories/data_repository.dart';
 import '../../home/bloc/home_bloc.dart';
 import '../../home/bloc/home_event.dart';
 import '../../home/bloc/home_state.dart';
@@ -13,9 +14,9 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create:
-          (_) =>
-              HomeBloc(sensorService: SensorService())..add(LoadSensorData()),
+      create: (_) => HomeBloc(
+        repository: DataRepository(apiService: VitalSyncApiService()),
+      )..add(LoadSensorData()),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Vital Sync Homepage'),

--- a/frontend/vital_sync_app/lib/features/home/view/widgets/sensor_card.dart
+++ b/frontend/vital_sync_app/lib/features/home/view/widgets/sensor_card.dart
@@ -6,7 +6,7 @@ class SensorCard extends StatelessWidget {
   final String label;
   final Color labelColor;
   final String value;
-  final ElevatedButton? actionButton;
+  final Widget? actionButton;
 
   const SensorCard({
     super.key,
@@ -15,7 +15,7 @@ class SensorCard extends StatelessWidget {
     required this.label,
     required this.labelColor,
     required this.value,
-    required this.actionButton,
+    this.actionButton,
   });
 
   @override
@@ -58,6 +58,10 @@ class SensorCard extends StatelessWidget {
                       color: labelColor,
                     ),
                   ),
+                  if (actionButton != null) ...[
+                    const SizedBox(height: 8),
+                    actionButton!,
+                  ],
                 ],
               ),
             ],


### PR DESCRIPTION
## Summary
- point `Config.vitalSyncApiUrl` at local FastAPI server
- return raw objects from `VitalSyncApiService` without trailing slash
- add `DataRepository.searchData` for `/data/search` endpoint
- pull data from backend in `HomeBloc` and display latest values
- make home event/state classes equatable
- allow optional action button in `SensorCard`
- wire up repository in `HomePage`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3d266dc832e8c24c1df945ac02e